### PR TITLE
Correct comment

### DIFF
--- a/src/gui/messagebox.c
+++ b/src/gui/messagebox.c
@@ -1751,7 +1751,7 @@ LCUI_MessageBox(	MB_ICON_TYPE icon_type, const char *text,
 	return ret;
 }
 
-/* ASCII版的LCUI_MessageBox */
+/* ANSI版的LCUI_MessageBox */
 LCUI_API int
 LCUI_MessageBoxA(	MB_ICON_TYPE icon_type, const char *text, 
 			const char *title, MB_BTN_TYPE button )


### PR DESCRIPTION
"A" means "ANSI (compatible encoding)" but not "ASCII (7-bit character set)".
XXX: Should use encoding-neutral routines (as like 'CP_ACP' for 'WideCharToMultiByte' in Windows) instead of hard-coded "GB2312".
