### PR TITLE
Add missing header to Makefile.am

### DIFF
--- a/include/LCUI/gui/Makefile.am
+++ b/include/LCUI/gui/Makefile.am
@@ -4,5 +4,5 @@ SUBDIRS=widget
 pkginclude_HEADERS = widget_base.h widget_task.h widget_prototype.h \
 widget_style.h widget_event.h widget_paint.h widget.h css_library.h \
 widget_helper.h css_parser.h css_rule_font_face.h css_fontstyle.h \
-builder.h metrics.h
+builder.h metrics.h widget_layout.h
 pkgincludedir=$(prefix)/include/LCUI/gui


### PR DESCRIPTION
Fixes #132.

Changes proposed in this pull request:
- append `widget_layout.h` to `pkginclude_HEADERS` in  [Makefile.am](https://github.com/lc-soft/LCUI/blob/ec07c09e0659d3ff19a7a6bb267b430a5473b31d/include/LCUI/gui/Makefile.am)

@lc-soft
