### PR TITLE
Use Fontconfig to get the font paths instead of relying on hardcoded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,11 @@ If you want to build full-featured LCUI, we suggest you install the following
  * [libxml2](http://xmlsoft.org/) — The XML C parser and toolkit
  * [libx11](https://www.x.org/) — X11 client-side library
  * [freetype](https://www.freetype.org/) — Font engine
+ * [fontconfig](https://www.freedesktop.org/wiki/Software/fontconfig/) — Font configuration & location
 
 If you system is Ubuntu, you can run following command to install dependencies:
 
-    apt-get install libpng-dev libjpeg-dev libxml2-dev libfreetype6-dev libx11-dev
+    apt-get install libpng-dev libjpeg-dev libxml2-dev libfreetype6-dev libx11-dev libfontconfig1-dev
 
 ### Building On Windows
 

--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,23 @@ else
 	want_font_engine=no
 fi
 
+# fontconfig
+want_fontconfig=yes
+AC_ARG_ENABLE(fontconfig, AC_HELP_STRING([--enable-fontconfig],
+[turn on fontconfig [[default=yes]]]), [want_fontconfig=$enableval])
+if test "$want_fontconfig" = yes; then
+	AC_CHECK_HEADERS([fontconfig/fontconfig.h], [
+		AC_CHECK_LIB([fontconfig], [FcInitLoadConfigAndFonts], [
+			want_fontconfig=yes
+			LCUI_LIBS="$LCUI_LIBS `pkg-config --libs fontconfig`"
+			CFLAGS="$CFLAGS `pkg-config --cflags-only-I fontconfig`"
+			AC_DEFINE_UNQUOTED([USE_FONTCONFIG], 1, [Define to 1 if you have Fontconfig.])
+		], [want_fontconfig=no])
+	], [want_fontconfig=no])
+else
+	want_fontconfig=no
+fi
+
 # 检测图形输出设备
 want_video_output=yes
 video_driver_name=framebuffer
@@ -192,6 +209,7 @@ echo -e "Build with lcui-builder support .... : $enable_builder"
 echo -e "Build with libpng support .......... : $want_png"
 echo -e "Build with libjpeg support ......... : $want_jpeg"
 echo -e "Build with font-engine support ..... : $font_engine_name"
+echo -e "Build with fontconfig support ...... : $want_fontconfig"
 echo -e "Build with thread support .......... : $thread_name"
 echo -e "Build with video support ........... : $video_driver_name"
 echo

--- a/include/LCUI/font.h
+++ b/include/LCUI/font.h
@@ -44,6 +44,6 @@
 #include <LCUI/font/textstyle.h>
 #include <LCUI/font/textlayer.h>
 #include <LCUI/font/charset.h>
-
+#include <LCUI/font/fontconfig.h>
 
 #endif

--- a/include/LCUI/font/Makefile.am
+++ b/include/LCUI/font/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS=foreign
 
 # Headers to install
-pkginclude_HEADERS = fontlibrary.h textlayer.h textstyle.h charset.h
+pkginclude_HEADERS = fontlibrary.h fontconfig.h textlayer.h textstyle.h charset.h
 pkgincludedir=$(prefix)/include/LCUI/font

--- a/include/LCUI/font/fontconfig.h
+++ b/include/LCUI/font/fontconfig.h
@@ -1,0 +1,40 @@
+/* ***************************************************************************
+ * fontconfig.c -- The Fontconfig support module.
+ *
+ * Copyright (c) 2018, Liu Chao <lc-soft@live.cn> All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of LCUI nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LCUI_FONTCONFIG_H
+#define LCUI_FONTCONFIG_H
+
+LCUI_BEGIN_HEADER
+
+char* Fontconfig_GetPath( char* name );
+
+LCUI_END_HEADER
+
+#endif

--- a/lcui.pc.in
+++ b/lcui.pc.in
@@ -7,5 +7,5 @@ Name: LCUI
 Description: LCUI is a simple graphical interface library
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lLCUI
-Libs.private: -lpthread -lfreetype -lpng -ljpeg -lX11 -lxml2
+Libs.private: -lpthread -lfreetype -lpng -ljpeg -lX11 -lxml2 -lfontconfig
 Cflags: -I${includedir}

--- a/src/font/Makefile.am
+++ b/src/font/Makefile.am
@@ -2,4 +2,4 @@ SUBDIRS = in-core
 AUTOMAKE_OPTIONS=foreign
 AM_CFLAGS = -I$(abs_top_srcdir)/include $(CODE_COVERAGE_CFLAGS)
 noinst_LTLIBRARIES = libfont.la
-libfont_la_SOURCES = fontlibrary.c freetype.c charset.c textstyle.c textlayer.c in_core_font.c
+libfont_la_SOURCES = fontlibrary.c freetype.c fontconfig.c charset.c textstyle.c textlayer.c in_core_font.c

--- a/src/font/fontconfig.c
+++ b/src/font/fontconfig.c
@@ -1,0 +1,71 @@
+/* ***************************************************************************
+ * fontconfig.c -- The Fontconfig support module.
+ *
+ * Copyright (c) 2018, Liu Chao <lc-soft@live.cn> All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of LCUI nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LCUI_BUILD_IN_WIN32
+
+#include <LCUI/config.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fontconfig/fontconfig.h>
+
+char* Fontconfig_GetPath( char* name )
+{
+#ifdef USE_FONTCONFIG
+	FcConfig* config = FcInitLoadConfigAndFonts();
+	char* path = "";
+
+	FcPattern* pat = FcNameParse( (const FcChar8*)name );
+	FcConfigSubstitute( config, pat, FcMatchPattern );
+	FcDefaultSubstitute( pat );
+
+	FcResult result;
+	FcPattern* font = FcFontMatch( config, pat, &result );
+
+	if( font ) {
+		FcChar8* file = NULL;
+		if( FcPatternGetString( font, FC_FILE, 0, &file ) == FcResultMatch ) {
+			size_t path_len = strlen( (char*)file ) + 1;
+			path = (char*)malloc( path_len );
+			memset( path, '\0', path_len );
+			strncpy( path, (char*)file, path_len );
+		}
+		FcPatternDestroy( font );
+	}
+
+	FcPatternDestroy( pat );
+	FcConfigDestroy( config );
+
+	return path;
+#else
+	return NULL;
+#endif
+}
+
+#endif

--- a/src/font/fontlibrary.c
+++ b/src/font/fontlibrary.c
@@ -834,24 +834,20 @@ void LCUI_InitFontLibrary( void )
 		{ FONTDIR"msyh.ttc", "Microsoft YaHei", NULL }
 	};
 #else
-#define FONTDIR "/usr/share/fonts/"
-#define MAX_FONTFILE_NUM 4
+#define MAX_FONTFILE_NUM 3
 	struct {
 		const char *path;
 		const char *family;
 		const char *style;
 	} fonts[MAX_FONTFILE_NUM] = {
 		{
-			FONTDIR"truetype/ubuntu-font-family/Ubuntu-R.ttf",
+			Fontconfig_GetPath( "Ubuntu" ),
 			"Ubuntu", NULL
 		}, {
-			FONTDIR"opentype/noto/NotoSansCJK-Regular.ttc",
+			Fontconfig_GetPath( "Noto Sans CJK SC" ),
 			"Noto Sans CJK SC", NULL
 		}, {
-			FONTDIR"opentype/noto/NotoSansCJK.ttc",
-			"Noto Sans CJK SC", NULL
-		}, {
-			FONTDIR"truetype/wqy/wqy-microhei.ttc",
+			Fontconfig_GetPath( "WenQuanYi Micro Hei" ),
 			"WenQuanYi Micro Hei", NULL
 		}
 	};
@@ -859,6 +855,7 @@ void LCUI_InitFontLibrary( void )
 
 	fontlib.font_cache_num = 1;
 	fontlib.font_cache = NEW( LCUI_FontCache, 1 );
+	ZEROSET( fontlib.font_cache, LCUI_FontCache );
 	fontlib.font_cache[0] = FontCache();
 	RBTree_Init( &fontlib.bitmap_cache );
 	fontlib.font_families_type = DictType_StringKey;
@@ -896,6 +893,11 @@ void LCUI_InitFontLibrary( void )
 			break;
 		}
 	}
+#ifndef LCUI_BUILD_IN_WIN32
+	for( i = 0; i < MAX_FONTFILE_NUM; ++i ) {
+		free( fonts[i].path );
+	}
+#endif
 }
 
 void LCUI_FreeFontLibrary( void )


### PR DESCRIPTION
Fixes #136.

@lc-soft