### PR TITLE
Fix to get the correct font file path (fix #181)

### DIFF
--- a/src/font/fontconfig.c
+++ b/src/font/fontconfig.c
@@ -28,6 +28,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #ifndef LCUI_BUILD_IN_WIN32
 
 #include <LCUI_Build.h>


### PR DESCRIPTION
Changes proposed in this pull request:
- include `config.h`

Applying this change, you can use Fontconfig_GetPath() to get the correct font file path.
**However, this change will cause memory leak in `make test`.**
What should i do?

## To reproduce
1. Build
```bash
$ make
```
2. Check that Fontconfig_GetPath() is getting the correct font file path
```bash
$ ./test/helloworld
...
[font] current font engine is: FreeType
[font] fontconfig enabled
[font] load file: /usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf
[font] add family: Ubuntu, style name: Regular, id: 2
[font] load file: /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
[font] add family: Noto Sans CJK JP, style name: Regular, id: 3
[font] add family: Noto Sans CJK KR, style name: Regular, id: 4
[font] add family: Noto Sans CJK SC, style name: Regular, id: 5
[font] add family: Noto Sans CJK TC, style name: Regular, id: 6
[font] add family: Noto Sans CJK HK, style name: Regular, id: 7
[font] add family: Noto Sans Mono CJK JP, style name: Regular, id: 8
[font] add family: Noto Sans Mono CJK KR, style name: Regular, id: 9
[font] add family: Noto Sans Mono CJK SC, style name: Regular, id: 10
[font] add family: Noto Sans Mono CJK TC, style name: Regular, id: 11
[font] add family: Noto Sans Mono CJK HK, style name: Regular, id: 12
[font] load file: /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
[font] add family: DejaVu Sans, style name: Book, id: 13
[font] select: Ubuntu
...
```
3.  Run `make test`
```bash
$ make test
...
[test] test_textedit(): wcscmp(L"hello", wcs) == 0. # PASS
[test] test_textedit(): 0 == TextEdit_GetTextLength(w). # PASS
[test] 223 tests, 223 pass.
==7290== 
==7290== HEAP SUMMARY:
==7290==     in use at exit: 2,027 bytes in 53 blocks
==7290==   total heap usage: 611,782 allocs, 611,729 frees, 419,116,934 bytes allocated
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 1 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B7E2: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10B759: test_xml_parser (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AE94: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 2 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83970: TextChar_UpdateBitmap.isra.5 (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E84E0A: TextLayer_ReloadCharBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E851B3: TextLayer_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B660: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10B759: test_xml_parser (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AE94: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 3 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B7E2: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10D899: test_widget_layout (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 4 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B7E2: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10F325: test_widget_inline_block_layout (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 5 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B7E2: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x110425: test_widget_opacity (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AEB0: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 6 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83970: TextChar_UpdateBitmap.isra.5 (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E84E0A: TextLayer_ReloadCharBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E851B3: TextLayer_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B660: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x110431: test_widget_opacity (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AEB0: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 7 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B7E2: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10EDD0: test_textview_resize (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AEBE: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 8 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83970: TextChar_UpdateBitmap.isra.5 (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E84E0A: TextLayer_ReloadCharBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E851B3: TextLayer_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B660: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71EB3: LCUIWidget_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x10EDD0: test_textview_resize (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AEBE: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 1 blocks are definitely lost in loss record 9 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83970: TextChar_UpdateBitmap.isra.5 (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83F55: TextLayer_ProcessText (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7E0A8: TextEdit_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x1115EF: test_textedit (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290==    by 0x10AEC5: main (in /home/d4yvector/develop/LCUI/test/.libs/test)
==7290== 
==7290== 0 bytes in 3 blocks are definitely lost in loss record 10 of 46
==7290==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7290==    by 0x4E824A9: FreeType_Render (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E81EB1: LCUIFont_GetBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E83970: TextChar_UpdateBitmap.isra.5 (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E84E0A: TextLayer_ReloadCharBitmap (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E851B3: TextLayer_Update (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7B660: TextView_OnTask (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E7193B: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290==    by 0x4E71A68: Widget_UpdateWithContext (in /home/d4yvector/develop/LCUI/src/.libs/libLCUI.so.0.1.1)
==7290== 
==7290== LEAK SUMMARY:
==7290==    definitely lost: 0 bytes in 12 blocks
==7290==    indirectly lost: 0 bytes in 0 blocks
==7290==      possibly lost: 0 bytes in 0 blocks
==7290==    still reachable: 2,027 bytes in 41 blocks
==7290==         suppressed: 0 bytes in 0 blocks
==7290== Reachable blocks (those to which a pointer was found) are not shown.
==7290== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==7290== 
==7290== For counts of detected and suppressed errors, rerun with: -v
==7290== ERROR SUMMARY: 10 errors from 10 contexts (suppressed: 0 from 0)
Makefile:942: recipe for target 'test' failed
make: *** [test] Error 42
...
```