### PR TITLE
perf: Add OpenMP support for widget rendering (#118)

### DIFF
--- a/build/windows/LCUI-Demo.sln
+++ b/build/windows/LCUI-Demo.sln
@@ -31,6 +31,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_border", "test_border\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_box_shadow", "test_box_shadow\test_box_shadow.vcxproj", "{83133071-0048-4400-92FD-842751D1EEDB}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_render", "test_render\test_render.vcxproj", "{A67C7DF6-B233-4125-883B-EF1424E1B52C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -186,6 +188,16 @@ Global
 		{83133071-0048-4400-92FD-842751D1EEDB}.Release|Win32.Build.0 = Release|Win32
 		{83133071-0048-4400-92FD-842751D1EEDB}.Release|x64.ActiveCfg = Release|x64
 		{83133071-0048-4400-92FD-842751D1EEDB}.Release|x64.Build.0 = Release|x64
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Debug|ARM.ActiveCfg = Debug|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Debug|Win32.Build.0 = Debug|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Debug|x64.ActiveCfg = Debug|x64
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Debug|x64.Build.0 = Debug|x64
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Release|ARM.ActiveCfg = Release|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Release|Win32.ActiveCfg = Release|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Release|Win32.Build.0 = Release|Win32
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Release|x64.ActiveCfg = Release|x64
+		{A67C7DF6-B233-4125-883B-EF1424E1B52C}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/windows/test_render/test_render.vcxproj
+++ b/build/windows/test_render/test_render.vcxproj
@@ -1,0 +1,192 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\test_render.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{a67c7df6-b233-4125-883b-ef1424e1b52c}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>test_render</RootNamespace>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)-windows\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\$(Platform)\objs\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)-windows\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\$(Platform)\objs\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)-windows\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\$(Platform)\objs\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules />
+    <CodeAnalysisRuleAssemblies />
+    <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)-windows\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Configuration)\$(Platform)\objs\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;BATCH_TEST;_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)\include\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LCUI.lib;LCUIMain.lib;</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;BATCH_TEST;_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)\include\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LCUI.lib;LCUIMain.lib;</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;BATCH_TEST;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)\include\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4819</DisableSpecificWarnings>
+      <BrowseInformation>true</BrowseInformation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LCUI.lib;LCUIMain.lib;</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <PreserveSbr>true</PreserveSbr>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;BATCH_TEST;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;$(SolutionDir)\include\..\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4819</DisableSpecificWarnings>
+      <BrowseInformation>true</BrowseInformation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>LCUI.lib;LCUIMain.lib;</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <PreserveSbr>true</PreserveSbr>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/build/windows/test_render/test_render.vcxproj.filters
+++ b/build/windows/test_render/test_render.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="源文件">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="头文件">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="资源文件">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\test_render.c">
+      <Filter>源文件</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,22 @@ if test "x$with_pthread" != "xno"; then
 	], [AC_MSG_ERROR([The support could not be configured for the POSIX thread programming interface.])])
 fi
 
+# openmp
+want_openmp=no
+AC_ARG_WITH(openmp, AC_HELP_STRING([--with-openmp], [use openmp (default)]))
+if test "x$with_openmp" != "xno"; then
+	AC_OPENMP
+	if test "x$OPENMP_CFLAGS" != "x"; then
+		want_openmp=yes
+		CFLAGS="$CFLAGS $OPENMP_CFLAGS"
+		AC_DEFINE_UNQUOTED(USE_OPENMP, 1, Define to 1 if you are using OpenMP support.)
+	else
+		AC_MSG_ERROR([The support could not be configured for the OpenMP.])
+	fi
+else
+	want_openmp=no
+fi
+
 # libxml2
 enable_builder=yes
 AC_ARG_ENABLE(lcui-builder, AC_HELP_STRING([--enable-lcui-builder],
@@ -227,6 +243,7 @@ echo -e "Build with libjpeg support ......... : $want_jpeg"
 echo -e "Build with font-engine support ..... : $font_engine_name"
 echo -e "Build with fontconfig support ...... : $want_fontconfig"
 echo -e "Build with thread support .......... : $thread_name"
+echo -e "Build with OpenMP support .......... : $want_openmp"
 echo -e "Build with video support ........... : $video_driver_name"
 echo
 

--- a/include/LCUI/config.h.in
+++ b/include/LCUI/config.h.in
@@ -159,6 +159,9 @@
 /* Define to 1 if you have the libpng. */
 #undef USE_LIBPNG
 
+/* Define to 1 if you are using OpenMP support. */
+#undef USE_OPENMP
+
 /* Version number of package */
 #undef VERSION
 

--- a/include/LCUI/surface.h
+++ b/include/LCUI/surface.h
@@ -55,6 +55,10 @@ LCUI_API LCUI_BOOL Surface_IsReady(LCUI_Surface surface);
 
 LCUI_API void Surface_Move(LCUI_Surface surface, int x, int y);
 
+LCUI_API int Surface_GetWidth(LCUI_Surface surface);
+
+LCUI_API int Surface_GetHeight(LCUI_Surface surface);
+
 LCUI_API void Surface_Resize(LCUI_Surface surface, int w, int h);
 
 LCUI_API void Surface_SetCaptionW(LCUI_Surface surface, const wchar_t *str);

--- a/include/LCUI/util/rect.h
+++ b/include/LCUI/util/rect.h
@@ -113,6 +113,13 @@ LCUI_API int RectList_Add(LinkedList *list, LCUI_Rect *rect);
 /** 删除脏矩形 */
 LCUI_API int RectList_Delete(LinkedList *list, LCUI_Rect *rect);
 
+/**
+ * Split each rectangle with the bounding box
+ */
+LCUI_API
+size_t RectList_SplitWith(LinkedList *rects, const LCUI_Rect *bounding,
+			  LinkedList *splited_rects);
+
 #define RectList_Clear(LIST) LinkedList_Clear(LIST, free)
 
 LCUI_END_HEADER

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS=foreign
-AM_CFLAGS = -I$(abs_top_srcdir)/include $(CODE_COVERAGE_CFLAGS) -fopenmp
+AM_CFLAGS = -I$(abs_top_srcdir)/include $(CODE_COVERAGE_CFLAGS)
 
 LCUI_LDFLAGS = -version-info 1:1:1
 LCUI_SOURCES = graph.c ime.c cursor.c worker.c main.c timer.c painter.c display.c keyboard.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS=foreign
-AM_CFLAGS = -I$(abs_top_srcdir)/include $(CODE_COVERAGE_CFLAGS)
+AM_CFLAGS = -I$(abs_top_srcdir)/include $(CODE_COVERAGE_CFLAGS) -fopenmp
 
 LCUI_LDFLAGS = -version-info 1:1:1
 LCUI_SOURCES = graph.c ime.c cursor.c worker.c main.c timer.c painter.c display.c keyboard.c

--- a/src/display.c
+++ b/src/display.c
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <LCUI/config.h>
+#include "config.h"
 
 #include <time.h>
 #include <stdio.h>
@@ -167,7 +167,6 @@ size_t LCUIDisplay_Render(void)
 		for (LinkedList_Each(rn, &rects)) {
 #ifdef USE_OPENMP
 #pragma omp task firstprivate(rn)
-			printf("thread_num: %d\n", omp_get_thread_num());
 #endif
 			rect = rn->data;
 			ev.paint.rect = *rect;

--- a/src/display.c
+++ b/src/display.c
@@ -30,6 +30,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <omp.h>
 #include <LCUI_Build.h>
 #include <LCUI/LCUI.h>
 #include <LCUI/input.h>
@@ -155,7 +156,12 @@ size_t LCUIDisplay_Render(void)
 		 */
 
 		/* Repaint dirty rectangles of surface */
+
+		#pragma omp parallel
+		#pragma omp single
 		for (LinkedList_Each(rn, &rects)) {
+			#pragma omp task firstprivate(rn)
+			printf("thread_num: %d\n", omp_get_thread_num());
 			rect = rn->data;
 			ev.paint.rect = *rect;
 			LCUI_TriggerEvent(&ev, NULL);
@@ -184,6 +190,7 @@ size_t LCUIDisplay_Render(void)
 			Surface_EndPaint(s, paint);
 			record->rendered = TRUE;
 		}
+		#pragma omp taskwait
 		RectList_Clear(&rects);
 		RectList_Clear(&record->rects);
 	}

--- a/src/display.c
+++ b/src/display.c
@@ -27,10 +27,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <LCUI/config.h>
+
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef USE_OPENMP
 #include <omp.h>
+#endif
 #include <LCUI_Build.h>
 #include <LCUI/LCUI.h>
 #include <LCUI/input.h>
@@ -156,12 +160,15 @@ size_t LCUIDisplay_Render(void)
 		 */
 
 		/* Repaint dirty rectangles of surface */
-
-		#pragma omp parallel
-		#pragma omp single
+#ifdef USE_OPENMP
+#pragma omp parallel
+#pragma omp single
+#endif
 		for (LinkedList_Each(rn, &rects)) {
-			#pragma omp task firstprivate(rn)
+#ifdef USE_OPENMP
+#pragma omp task firstprivate(rn)
 			printf("thread_num: %d\n", omp_get_thread_num());
+#endif
 			rect = rn->data;
 			ev.paint.rect = *rect;
 			LCUI_TriggerEvent(&ev, NULL);
@@ -190,7 +197,9 @@ size_t LCUIDisplay_Render(void)
 			Surface_EndPaint(s, paint);
 			record->rendered = TRUE;
 		}
-		#pragma omp taskwait
+#ifdef USE_OPENMP
+#pragma omp taskwait
+#endif
 		RectList_Clear(&rects);
 		RectList_Clear(&record->rects);
 	}

--- a/src/display.c
+++ b/src/display.c
@@ -136,7 +136,7 @@ static void SurfaceRecord_DumpRects(SurfaceRecord record,
 static size_t LCUIDisplay_RenderSurface(SurfaceRecord record)
 {
 	size_t count = 0;
-	int i = 0;
+	int i;
 	LCUI_Rect *rect;
 	LCUI_PaintContext paint;
 	LCUI_SysEventRec ev;
@@ -153,6 +153,7 @@ static size_t LCUIDisplay_RenderSurface(SurfaceRecord record)
 	SurfaceRecord_DumpRects(record, &rects);
 
 	rectArray = (LCUI_Rect **)malloc(sizeof(LCUI_Rect*) * rects.length);
+	i = 0;
 	for (LinkedList_Each(node, &rects)) {
 		rectArray[i] = node->data;
 		i++;

--- a/src/gui/widget_base.c
+++ b/src/gui/widget_base.c
@@ -392,7 +392,7 @@ void Widget_GenerateHash(LCUI_Widget w)
 	LinkedListNode *node;
 
 	Widget_GenerateSelfHash(w);
-	for (LinkedList_Each(node, &w->children_show)) {
+	for (LinkedList_Each(node, &w->children)) {
 		Widget_GenerateHash(node->data);
 	}
 }

--- a/src/platform/linux/linux_x11display.c
+++ b/src/platform/linux/linux_x11display.c
@@ -399,6 +399,16 @@ static void *X11Surface_GetHandle(LCUI_Surface s)
 	return NULL;
 }
 
+static int X11Surface_GetWidth(LCUI_Surface s)
+{
+	return s->width;
+}
+
+static int X11Surface_GetHeight(LCUI_Surface s)
+{
+	return s->height;
+}
+
 static int X11Display_GetWidth(void)
 {
 	Screen *s = DefaultScreenOfDisplay(x11.app->display);
@@ -476,6 +486,8 @@ LCUI_DisplayDriver LCUI_CreateLinuxX11DisplayDriver(void)
 	driver->beginPaint = X11Surface_BeginPaint;
 	driver->endPaint = X11Surface_EndPaint;
 	driver->bindEvent = X11Display_BindEvent;
+	driver->getSurfaceWidth = X11Surface_GetWidth;
+	driver->getSurfaceHeight = X11Surface_GetHeight;
 	LinkedList_Init(&x11.surfaces);
 	LCUI_BindSysEvent(Expose, OnExpose, NULL, NULL);
 	LCUI_BindSysEvent(ConfigureNotify, OnConfigureNotify, NULL, NULL);

--- a/src/util/rect.c
+++ b/src/util/rect.c
@@ -472,3 +472,16 @@ int RectList_Delete(LinkedList *list, LCUI_Rect *rect)
 	LinkedList_Concat(list, &extra_list);
 	return 1;
 }
+
+size_t RectList_SplitWith(LinkedList *rects, const LCUI_Rect *bounding,
+			  LinkedList *splited_rects)
+{
+	LCUI_Rect splited_rect;
+	LinkedListNode *node;
+
+	for (LinkedList_Each(node, rects)) {
+		LCUIRect_GetOverlayRect(bounding, node->data, &splited_rect);
+		RectList_AddEx(splited_rects, &splited_rect, FALSE);
+	}
+	return splited_rects->length;
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,7 +6,7 @@ noinst_PROGRAMS = helloworld test test_charset test_touch test_char_render \
 test_string_render test_widget_render test_widget_layout  test_widget_rect \
 test_widget_opacity test_widget_flex_layout test_widget_inline_block_layout \
 test_scaling_support test_widget test_scrollbar test_textview_resize \
-test_image_scaling_bench
+test_image_scaling_bench test_render
 
 ##指定测试程序的源码文件
 helloworld_SOURCES = helloworld.c
@@ -69,6 +69,9 @@ test_scrollbar_LDADD = $(top_builddir)/src/libLCUI.la
 
 test_widget_SOURCES = test_widget.c
 test_widget_LDADD = $(top_builddir)/src/libLCUI.la
+
+test_render_SOURCES = test_render.c
+test_render_LDADD = $(top_builddir)/src/libLCUI.la
 
 test_image_scaling_bench_LDADD = $(top_builddir)/src/libLCUI.la
 

--- a/test/test_render.c
+++ b/test/test_render.c
@@ -1,0 +1,92 @@
+#include <LCUI_Build.h>
+#include <LCUI/LCUI.h>
+#include <LCUI/gui/widget.h>
+#include <LCUI/gui/widget/textview.h>
+#include <LCUI/display.h>
+#include <LCUI/timer.h>
+#include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define SCREEN_WIDTH 1920
+#define SCREEN_HEIGHT 1080
+
+void UpdateWidgetStyle(LCUI_Widget w, void *arg)
+{
+	LCUI_Color color;
+
+	color.red = 255;
+	color.green = (unsigned char)(rand() % 255);
+	color.blue = 0;
+	color.alpha = 255;
+	Widget_SetStyle(w, key_background_color, color, color);
+}
+
+void UpdateFrame(void *arg)
+{
+	Widget_Each(arg, UpdateWidgetStyle, NULL);
+	LCUIWidget_RefreshStyle();
+}
+
+void UpdateRenderStatus(void *arg)
+{
+	char str[32];
+
+	sprintf(str, "[size=24px]FPS: %d[/size]", LCUI_GetFrameCount());
+	TextView_SetText(arg, str);
+}
+
+int main(void)
+{
+	size_t i;
+	time_t t;
+	LCUI_Widget root;
+	LCUI_Widget w;
+	LCUI_Widget box;
+	LCUI_Widget status;
+	LCUI_Color white = RGB(255, 255, 255);
+	LCUI_Color black = RGB(0, 0, 0);
+
+	srand(time(NULL));
+	Logger_SetLevel(LOGGER_LEVEL_WARNING);
+	LCUI_Init();
+	LCUIDisplay_SetSize(SCREEN_WIDTH, SCREEN_HEIGHT);
+	root = LCUIWidget_GetRoot();
+	box = LCUIWidget_New(NULL);
+	for (i = 0; i < SCREEN_WIDTH * SCREEN_HEIGHT / 100; ++i) {
+		w = LCUIWidget_New(NULL);
+		Widget_Resize(w, 10.0f, 10.0f);
+		Widget_SetStyle(w, key_display, SV_INLINE_BLOCK, style);
+		Widget_Append(box, w);
+	}
+
+	status = LCUIWidget_New("textview");
+	Widget_SetStyle(status, key_top, 10, px);
+	Widget_SetStyle(status, key_right, 10, px);
+	Widget_SetStyle(status, key_position, SV_ABSOLUTE, style);
+	Widget_SetStyle(status, key_background_color, black, color);
+	Widget_SetPadding(status, 10, 15, 10, 15);
+	TextView_SetColor(status, white);
+	Widget_Append(root, box);
+	Widget_Append(root, status);
+
+#ifdef WITH_WINDOW
+	LCUI_SetInterval(LCUI_MAX_FRAME_MSEC, UpdateFrame, box);
+	LCUI_SetInterval(1000, UpdateRenderStatus, status);
+	return LCUI_Main();
+#else
+	printf("running rendering performance test\n");
+	t = clock();
+	for (i = 0; i < 120; ++i) {
+		UpdateFrame(box);
+		LCUIWidget_Update();
+		LCUIDisplay_Update();
+		LCUIDisplay_Render();
+		LCUIDisplay_Present();
+	}
+	t = clock() - t;
+	printf("rendered %zu frames in %.2lfs, rendering speed is %.2lf fps\n",
+	       i, t * 1.0 / CLOCKS_PER_SEC, i * CLOCKS_PER_SEC * 1.0 / t);
+	return 0;
+#endif
+}

--- a/test/test_render.c
+++ b/test/test_render.c
@@ -80,6 +80,7 @@ void InitBackground(void)
 	LCUI_Widget w;
 	LCUI_Widget root;
 	LCUI_Color color;
+	LCUI_WidgetRulesRec rules = { 0 };
 	const float width = SCREEN_WIDTH * 1.0f / n;
 	const float height = SCREEN_HEIGHT * 1.0f / n;
 
@@ -101,6 +102,13 @@ void InitBackground(void)
 		Widget_SetStyle(w, key_background_color, color, color);
 		Widget_Append(self.box, w);
 	}
+	rules.cache_children_style = TRUE;
+	rules.ignore_classes_change = TRUE;
+	rules.ignore_status_change = TRUE;
+	rules.max_update_children_count = -1;
+	rules.max_render_children_count = 0;
+	Widget_GenerateHash(self.box);
+	Widget_SetRules(self.box, &rules);
 	Widget_Append(root, self.box);
 }
 


### PR DESCRIPTION
## Purpose
Add OpenMP support for widget rendering (#118) .

## Changes
- Modified src/Makefile.am and added compiler option.
- Modified src/display.c and added preprocessor directives for OpenMP.
- To check whether multithreading is possible, the string is output to standard output. However, I will remove it before merging.

## Screenshots
- When OpenMP is not supported(change before)
![openmp_is_not_supported](https://user-images.githubusercontent.com/9170826/70626664-346da980-1c68-11ea-9717-11fc86408849.png)

- When OpenMP is supported(change after)
![openmp_is_supported](https://user-images.githubusercontent.com/9170826/70621588-49910b00-1c5d-11ea-8f24-47fe48f7cf93.png)

I printed `thread_num` to confirm that multiple threads were used.
If there are no problems with the review, I will remove the `thread_num` output.

## To reproduce
```bash
$ make
$ make test
```

In `make test`, there is only one rectangle in `rects`, the execution time was slightly longer due to overhead.
I measured it with `time make test`.