### PR TITLE
fix(mainloop): move out paint event trigger from openmp parallel loop (#204)

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -274,12 +274,8 @@ static size_t LCUIDisplay_RenderSurfaceRect(SurfaceRecord record,
 					    LCUI_Rect *rect)
 {
 	size_t count;
-	LCUI_SysEventRec ev;
 	LCUI_PaintContext paint;
 
-	ev.type = LCUI_PAINT;
-	ev.paint.rect = *rect;
-	LCUI_TriggerEvent(&ev, NULL);
 	if (!record->widget || !record->surface ||
 	    !Surface_IsReady(record->surface)) {
 		return 0;
@@ -321,7 +317,12 @@ static size_t LCUIDisplay_RenderSurface(SurfaceRecord record)
 	}
 	rect_array = (LCUI_Rect **)malloc(sizeof(LCUI_Rect *) * rects.length);
 	for (LinkedList_Each(node, &rects)) {
+		LCUI_SysEventRec ev;
+
 		rect_array[i] = node->data;
+		ev.type = LCUI_PAINT;
+		ev.paint.rect = *rect_array[i];
+		LCUI_TriggerEvent(&ev, NULL);
 		dirty += rect_array[i]->width * rect_array[i]->height;
 		i++;
 	}

--- a/test/test_mainloop.c
+++ b/test/test_mainloop.c
@@ -37,14 +37,17 @@ static void OnTriggerBtnClick(void *arg)
 	e.button.x = 5;
 	e.button.y = 5;
 	LCUI_TriggerEvent(&e, NULL);
+
+	e.type = LCUI_MOUSEUP;
+	LCUI_TriggerEvent(&e, NULL);
 }
 
 static void ObserverThread(void *arg)
 {
-	LCUI_BOOL exited = *((LCUI_BOOL*)arg);
+	LCUI_BOOL *exited = (LCUI_BOOL*)arg;
 
 	LCUI_MSleep(100);
-	it_b("main loop should exit after 50ms", exited, TRUE);
+	it_b("main loop should exit after 50ms", *exited, TRUE);
 	if (!exited) {
 		exit(-print_test_result());
 		return;


### PR DESCRIPTION
Fixes #204 .

Changes proposed in this pull request:
- openmp parallel threads blocks in LCUI_TriggerEvent on locking System.event.mutex
- fix some bug in test

@lc-soft
