### PR TITLE
fix(gui): incorrect horizontal scroll bar style (#219)

### DIFF
--- a/build/windows/LCUITest/LCUITest.vcxproj
+++ b/build/windows/LCUITest/LCUITest.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="..\..\..\test\test_linkedlist.c" />
     <ClCompile Include="..\..\..\test\test_mainloop.c" />
     <ClCompile Include="..\..\..\test\test_object.c" />
+    <ClCompile Include="..\..\..\test\test_scrollbar.c" />
     <ClCompile Include="..\..\..\test\test_settings.c" />
     <ClCompile Include="..\..\..\test\test_string.c" />
     <ClCompile Include="..\..\..\test\test_strpool.c" />

--- a/build/windows/LCUITest/LCUITest.vcxproj.filters
+++ b/build/windows/LCUITest/LCUITest.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\..\..\test\test_mainloop.c">
       <Filter>源文件</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\test\test_scrollbar.c">
+      <Filter>源文件</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\test\test.h">

--- a/include/LCUI/gui/widget/scrollbar.h
+++ b/include/LCUI/gui/widget/scrollbar.h
@@ -33,10 +33,15 @@
 
 LCUI_BEGIN_HEADER
 
-enum ScrollBarDirection {
-	SBD_HORIZONTAL,
-	SBD_VERTICAL
-};
+typedef enum LCUI_ScrollBarDirection {
+	LCUI_SCROLLBAR_HORIZONTAL,
+	LCUI_SCROLLBAR_VERTICAL
+} LCUI_ScrollBarDirection;
+
+/* TODO: remove these macro in next major version */
+
+#define SBD_HORIZONTAL LCUI_SCROLLBAR_HORIZONTAL
+#define SBD_VERTICAL LCUI_SCROLLBAR_VERTICAL
 
 LCUI_API void ScrollBar_BindBox(LCUI_Widget w, LCUI_Widget box);
 
@@ -49,7 +54,8 @@ LCUI_API int ScrollBar_GetPosition(LCUI_Widget w);
 LCUI_API int ScrollBar_SetPosition(LCUI_Widget w, int pos);
 
 /** 设置滚动条的方向 */
-LCUI_API void ScrollBar_SetDirection(LCUI_Widget w, int direction);
+LCUI_API void ScrollBar_SetDirection(LCUI_Widget w,
+				     LCUI_ScrollBarDirection direction);
 
 LCUI_API void LCUIWidget_AddTScrollBar(void);
 

--- a/src/gui/widget/scrollbar.c
+++ b/src/gui/widget/scrollbar.c
@@ -46,52 +46,74 @@
 
 /** 惯性滚动效果的相关数据 */
 typedef struct InertialScrollingRec_ {
-	int start_pos;			/**< 开始移动时的位置 */
-	int end_pos;			/**< 结束移动时的位置 */
-	int timer;			/**< 定时器 */
-	int interval;			/**< 定时器的间隔时间 */
-	double speed;			/**< 滚动速度 */
-	double speed_delta;		/**< 速度差（加速度） */
-	int64_t timestamp;		/**< 开始时间 */
-	LCUI_BOOL is_running;		/**< 当前效果是否正在运行 */
+	int start_pos;		/**< 开始移动时的位置 */
+	int end_pos;		/**< 结束移动时的位置 */
+	int timer;		/**< 定时器 */
+	int interval;		/**< 定时器的间隔时间 */
+	double speed;		/**< 滚动速度 */
+	double speed_delta;	/**< 速度差（加速度） */
+	int64_t timestamp;	/**< 开始时间 */
+	LCUI_BOOL is_running;	/**< 当前效果是否正在运行 */
 } InertialScrollingRec, *InertialScrolling;
 
 /** 滚动条的相关数据 */
 typedef struct LCUI_ScrollBarRec_ {
-	LCUI_Widget box;		/**< a container containing scrollbar and target, the default is the parent of scrollbar */
-	LCUI_Widget target;		/**< scroll target */
-	LCUI_Widget slider;		/**< slider of scrollbar */
-	LCUI_BOOL is_dragged;		/**< whether the target is dragged */
-	LCUI_BOOL is_draggable;		/**< whether the target can be dragged */
-	float slider_x, slider_y;	/**< 拖拽开始时的滑块位置 */
-	int mouse_x, mouse_y;		/**< 拖拽开始时的鼠标坐标 */
-	int touch_point_id;		/**< 触点的ID */
-	int direction;			/**< 滚动条的方向（垂直或水平） */
-	int scroll_step;		/**< 每次滚动的距离，主要针对使用鼠标滚轮触发的滚动 */
-	int pos;			/**< 当前的位置 */
-	int old_pos;			/**< 拖拽开始时的位置 */
-	int distance;			/**< 滚动距离 */
-	int64_t timestamp;		/**< 数据更新时间，主要针对触控拖动时的位置变化 */
-	InertialScrollingRec effect;	/**< 用于实现惯性滚动效果的相关数据 */
+	/** a container containing scrollbar and target, the default is the parent of scrollbar */
+	LCUI_Widget box;
+	LCUI_Widget target;			/**< scroll target */
+	LCUI_Widget thumb;			/**< thumb of scrollbar */
+	LCUI_BOOL is_dragging;			/**< whether the target is dragged */
+	LCUI_BOOL is_draggable;			/**< whether the target can be dragged */
+	LCUI_ScrollBarDirection direction;	/**< 滚动条的方向（垂直或水平） */
+	float thumb_x, thumb_y;			/**< 拖拽开始时的滑块位置 */
+	int mouse_x, mouse_y;			/**< 拖拽开始时的鼠标坐标 */
+	int touch_point_id;			/**< 触点的ID */
+	int scroll_step;			/**< 每次滚动的距离，主要针对使用鼠标滚轮触发的滚动 */
+	int pos;				/**< 当前的位置 */
+	int old_pos;				/**< 拖拽开始时的位置 */
+	int distance;				/**< 滚动距离 */
+	int64_t timestamp;			/**< 数据更新时间，主要针对触控拖动时的位置变化 */
+	InertialScrollingRec effect;		/**< 用于实现惯性滚动效果的相关数据 */
 } LCUI_ScrollBarRec, *LCUI_ScrollBar;
 
-static struct LCUI_ScrollbarModule {
-	int event_id;
-	LCUI_WidgetPrototype prototype;
-} self;
+static LCUI_WidgetPrototype scrollbar_prototype;
 
 static const char *scrollbar_css = CodeToString(
 
 scrollbar {
+	display: flex;
+	position: absolute;
+	background-color: #fafafa;
+	box-sizing: border-box;
+}
+
+.scrollbar-track {
+	flex: auto;
+}
+
+scrollbar.vertical {
 	top: 0;
 	right: 0;
 	width: 14px;
 	height: 100%;
-	position: absolute;
-	background-color: #fafafa;
-	border: 1px solid #eee;
+	flex-direction: column;
 }
-.scrollbar-slider {
+
+scrollbar.horizontal {
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 14px;
+}
+
+.scrollbar-corner {
+	flex: none;
+	width: 14px;
+	height: 14px;
+	display: none;
+}
+
+.scrollbar-thumb {
 	top: 0;
 	left: 0;
 	width: 14px;
@@ -101,31 +123,34 @@ scrollbar {
 	position: absolute;
 	background-color: #aaa;
 }
-.scrollbar-slider:hover {
+
+.scrollbar-thumb:hover {
 	background-color: #bbb;
 }
-.scrollbar-slider:active {
+
+.scrollbar-thumb:active {
 	background-color: #999;
 }
+
 .scrollbar-target {
 	top: 0;
 	left: 0;
 	position: relative;
 }
-.scrollbar-horizontal {
-	right: auto;
-	top: auto;
-	bottom: 0;
-	left: 0;
-	width: 100%;
-	height: 14px;
-}
+
 .has-horizontal-scrollbar {
 	padding-bottom: 14px;
 }
+
 .has-vertical-scrollbar {
 	padding-right: 14px;
 }
+
+.has-horizontal-scrollbar scrollbar.vertical .scrollbar-corner,
+.has-vertical-scrollbar scrollbar.horizontal .scrollbar-corner {
+	display: block;
+}
+
 );
 
 /* clang-format on */
@@ -138,7 +163,7 @@ static void OnInertialScrolling(void *arg)
 	InertialScrolling effect;
 	LCUI_Widget w = arg;
 
-	scrollbar = Widget_GetData(w, self.prototype);
+	scrollbar = Widget_GetData(w, scrollbar_prototype);
 	effect = &scrollbar->effect;
 	time = (double)LCUI_GetTimeDelta(effect->timestamp) / 1000;
 	distance = (effect->speed + 0.5 * effect->speed_delta * time) * time;
@@ -188,7 +213,7 @@ static void StartInertialScrolling(LCUI_Widget w)
 	LCUI_ScrollBar scrollbar;
 	InertialScrolling effect;
 
-	scrollbar = Widget_GetData(w, self.prototype);
+	scrollbar = Widget_GetData(w, scrollbar_prototype);
 	effect = &scrollbar->effect;
 	effect->end_pos = scrollbar->pos;
 	distance = effect->end_pos - effect->start_pos;
@@ -217,114 +242,86 @@ static void StartInertialScrolling(LCUI_Widget w)
 		  distance, (int)time_delta);
 }
 
-static void Slider_OnMouseMove(LCUI_Widget slider, LCUI_WidgetEvent e,
-			       void *arg)
+static void ScrollBarThumb_OnMouseMove(LCUI_Widget thumb, LCUI_WidgetEvent e,
+				       void *arg)
 {
 	LCUI_Widget target;
+	LCUI_Widget box;
 	LCUI_Widget w = e->data;
 	LCUI_ScrollBar scrollbar;
-	float n, box_size, size, layer_pos, x, y;
+	float size, layer_pos, x, y;
 
-	scrollbar = Widget_GetData(w, self.prototype);
-	if (!scrollbar->is_dragged || !scrollbar->target) {
+	scrollbar = Widget_GetData(w, scrollbar_prototype);
+	box = scrollbar->box ? scrollbar->box : w->parent;
+	if (!scrollbar->is_dragging || !scrollbar->target) {
 		return;
 	}
 	target = scrollbar->target;
-	if (scrollbar->direction == SBD_HORIZONTAL) {
+	if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
+		size = thumb->parent->box.content.width - thumb->width;
+		x = scrollbar->thumb_x + e->motion.x - scrollbar->mouse_x;
+		x = max(0, min(x, size));
 		y = 0;
-		x = scrollbar->slider_x;
-		x += e->motion.x - scrollbar->mouse_x;
-		if (scrollbar->box) {
-			box_size = scrollbar->box->box.content.width;
-		} else {
-			box_size = w->parent->box.content.width;
-		}
-		layer_pos = scrollbar->target->box.outer.width - box_size;
-		size = w->box.content.width - slider->width;
-		if (x > size) {
-			x = size;
-		} else if (x < 0) {
-			x = 0;
-		}
-		n = 0.0;
-		if (size > 0) {
-			n = slider->x / size;
-			if (n > 1.0) {
-				n = 1;
-			}
-		}
-		layer_pos = layer_pos * n;
+		layer_pos = (scrollbar->target->box.outer.width -
+			     box->box.content.width) *
+			    max(0, min(x / size, 1.0));
 		Widget_SetStyle(target, key_left, -layer_pos, px);
 	} else {
+		size = thumb->parent->box.content.height - thumb->height;
 		x = 0;
-		y = scrollbar->slider_y;
-		y += e->motion.y - scrollbar->mouse_y;
-		if (scrollbar->box) {
-			box_size = scrollbar->box->box.content.height;
-		} else {
-			box_size = w->parent->box.content.height;
-		}
-		layer_pos = scrollbar->target->box.outer.height - box_size;
-		size = w->box.content.height - slider->height;
-		if (y > size) {
-			y = size;
-		} else if (y < 0) {
-			y = 0;
-		}
-		n = 0.0;
-		if (size > 0) {
-			n = slider->y / size;
-			if (n > 1.0) {
-				n = 1;
-			}
-		}
-		layer_pos = layer_pos * n;
+		y = scrollbar->thumb_y + e->motion.y - scrollbar->mouse_y;
+		y = max(0, min(y, size));
+		layer_pos = (scrollbar->target->box.outer.height -
+			     box->box.content.height) *
+			    max(0, min(y / size, 1.0));
 		Widget_SetStyle(target, key_top, -layer_pos, px);
 	}
 	if (scrollbar->pos != iround(layer_pos)) {
-		LCUI_WidgetEventRec e = { 0 };
-		e.type = self.event_id;
+		LCUI_WidgetEventRec e;
+		LCUI_InitWidgetEvent(&e, "scroll");
 		e.cancel_bubble = TRUE;
 		Widget_TriggerEvent(target, &e, &layer_pos);
 	}
 	scrollbar->pos = iround(layer_pos);
 	Widget_UpdateStyle(target, FALSE);
-	Widget_Move(slider, x, y);
+	Widget_Move(thumb, x, y);
 }
 
-static void Slider_OnMouseUp(LCUI_Widget slider, LCUI_WidgetEvent e, void *arg)
+static void ScrollBarThumb_OnMouseUp(LCUI_Widget thumb, LCUI_WidgetEvent e,
+				     void *arg)
 {
 	LCUI_Widget w = e->data;
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
-	Widget_UnbindEvent(slider, "mousemove", Slider_OnMouseMove);
-	Widget_UnbindEvent(slider, "mouseup", Slider_OnMouseUp);
-	Widget_ReleaseMouseCapture(slider);
-	scrollbar->is_dragged = FALSE;
+	Widget_UnbindEvent(thumb, "mousemove", ScrollBarThumb_OnMouseMove);
+	Widget_UnbindEvent(thumb, "mouseup", ScrollBarThumb_OnMouseUp);
+	Widget_ReleaseMouseCapture(thumb);
+	scrollbar->is_dragging = FALSE;
 }
 
-static void Slider_OnMouseDown(LCUI_Widget slider, LCUI_WidgetEvent e,
-			       void *arg)
+static void ScrollBarThumb_OnMouseDown(LCUI_Widget thumb, LCUI_WidgetEvent e,
+				       void *arg)
 {
 	LCUI_Widget w = e->data;
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
-	if (scrollbar->is_dragged) {
+	if (scrollbar->is_dragging) {
 		return;
 	}
-	scrollbar->slider_x = slider->x;
-	scrollbar->slider_y = slider->y;
+	scrollbar->thumb_x = thumb->x;
+	scrollbar->thumb_y = thumb->y;
 	scrollbar->mouse_x = e->motion.x;
 	scrollbar->mouse_y = e->motion.y;
-	scrollbar->is_dragged = TRUE;
-	Widget_SetMouseCapture(slider);
-	Widget_BindEvent(slider, "mousemove", Slider_OnMouseMove, w, NULL);
-	Widget_BindEvent(slider, "mouseup", Slider_OnMouseUp, w, NULL);
+	scrollbar->is_dragging = TRUE;
+	Widget_SetMouseCapture(thumb);
+	Widget_BindEvent(thumb, "mousemove", ScrollBarThumb_OnMouseMove, w,
+			 NULL);
+	Widget_BindEvent(thumb, "mouseup", ScrollBarThumb_OnMouseUp, w, NULL);
 }
 
 static void ScrollBar_OnLink(LCUI_Widget w, LCUI_WidgetEvent e, void *arg)
 {
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 	if (!scrollbar->box) {
 		ScrollBar_BindBox(w, w->parent);
 	}
@@ -340,39 +337,49 @@ static void ScrollBar_OnBoxDestroy(LCUI_Widget box, LCUI_WidgetEvent e,
 
 static void ScrollBar_OnInit(LCUI_Widget w)
 {
-	LCUI_Widget slider;
-	LCUI_ScrollBar scrollbar;
+	LCUI_Widget track;
+	LCUI_Widget corner;
+	LCUI_ScrollBar self;
 	const size_t data_size = sizeof(LCUI_ScrollBarRec);
 
-	slider = LCUIWidget_New(NULL);
-	scrollbar = Widget_AddData(w, self.prototype, data_size);
-	scrollbar->direction = SBD_VERTICAL;
-	scrollbar->is_dragged = FALSE;
-	scrollbar->is_draggable = FALSE;
-	scrollbar->scroll_step = 64;
-	scrollbar->slider = slider;
-	scrollbar->target = NULL;
-	scrollbar->box = NULL;
-	scrollbar->old_pos = 0;
-	scrollbar->pos = 0;
-	scrollbar->touch_point_id = -1;
-	InitInertialScrolling(&scrollbar->effect);
-	Widget_BindEvent(slider, "mousedown", Slider_OnMouseDown, w, NULL);
+	self = Widget_AddData(w, scrollbar_prototype, data_size);
+	self->direction = LCUI_SCROLLBAR_VERTICAL;
+	self->is_dragging = FALSE;
+	self->is_draggable = FALSE;
+	self->scroll_step = 64;
+	self->target = NULL;
+	self->box = NULL;
+	self->old_pos = 0;
+	self->pos = 0;
+	self->touch_point_id = -1;
+	self->thumb = LCUIWidget_New(NULL);
+	track = LCUIWidget_New(NULL);
+	corner = LCUIWidget_New(NULL);
+
+	Widget_AddClass(track, "scrollbar-track");
+	Widget_AddClass(corner, "scrollbar-corner");
+	Widget_AddClass(self->thumb, "scrollbar-thumb");
+	Widget_BindEvent(self->thumb, "mousedown", ScrollBarThumb_OnMouseDown,
+			 w, NULL);
 	Widget_BindEvent(w, "link", ScrollBar_OnLink, NULL, NULL);
-	Widget_AddClass(slider, "scrollbar-slider");
-	Widget_Append(w, slider);
+	Widget_Append(track, self->thumb);
+	Widget_Append(w, track);
+	Widget_Append(w, corner);
+
+	InitInertialScrolling(&self->effect);
+	ScrollBar_SetDirection(w, LCUI_SCROLLBAR_VERTICAL);
 }
 
 static void ScrollBar_UpdateSize(LCUI_Widget w)
 {
 	float n = 1.0, size, box_size;
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
-	LCUI_Widget slider = scrollbar->slider;
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
+	LCUI_Widget thumb = scrollbar->thumb;
 
 	if (!scrollbar->box) {
 		return;
 	}
-	if (scrollbar->direction == SBD_HORIZONTAL) {
+	if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
 		if (scrollbar->target) {
 			size = scrollbar->target->box.outer.width;
 		} else {
@@ -382,7 +389,7 @@ static void ScrollBar_UpdateSize(LCUI_Widget w)
 		if (size > box_size && box_size > 0) {
 			n = box_size / size;
 		}
-		Widget_SetStyle(slider, key_width, n, scale);
+		Widget_SetStyle(thumb, key_width, n, scale);
 	} else {
 		if (scrollbar->target) {
 			size = scrollbar->target->box.outer.height;
@@ -393,13 +400,13 @@ static void ScrollBar_UpdateSize(LCUI_Widget w)
 		if (size > box_size && box_size > 0) {
 			n = box_size / size;
 		}
-		Widget_SetStyle(slider, key_height, n, scale);
+		Widget_SetStyle(thumb, key_height, n, scale);
 	}
 	ScrollBar_SetPosition(w, scrollbar->pos);
-	Widget_UpdateStyle(slider, FALSE);
+	Widget_UpdateStyle(thumb, FALSE);
 	if (n < 1.0) {
 		Widget_Show(w);
-		if (scrollbar->direction == SBD_HORIZONTAL) {
+		if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
 			Widget_AddClass(scrollbar->box,
 					"has-horizontal-scrollbar");
 		} else {
@@ -408,7 +415,7 @@ static void ScrollBar_UpdateSize(LCUI_Widget w)
 		}
 	} else {
 		Widget_Hide(w);
-		if (scrollbar->direction == SBD_HORIZONTAL) {
+		if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
 			Widget_RemoveClass(scrollbar->box,
 					   "has-horizontal-scrollbar");
 		} else {
@@ -423,8 +430,13 @@ static void ScrollBox_OnWheel(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 	int pos, new_pos;
 
 	LCUI_Widget w = e->data;
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
+	// TODO: Add support to handle horizontal scrolling
+	// https://docs.microsoft.com/en-us/windows/win32/controls/scroll-bars
+	if (scrollbar->direction != LCUI_SCROLLBAR_VERTICAL) {
+		return;
+	}
 	pos = ScrollBar_GetPosition(w);
 	if (e->wheel.delta > 0) {
 		new_pos = pos - scrollbar->scroll_step;
@@ -451,7 +463,7 @@ static void ScrollBox_OnTouch(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 	if (e->touch.n_points < 1) {
 		return;
 	}
-	scrollbar = Widget_GetData(w, self.prototype);
+	scrollbar = Widget_GetData(w, scrollbar_prototype);
 	if (scrollbar->touch_point_id == -1) {
 		point = &e->touch.points[0];
 		/* 如果这个触点的状态不是 TOUCHDOWN，则说明是上次触控拖拽操
@@ -477,7 +489,7 @@ static void ScrollBox_OnTouch(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 		scrollbar->effect.speed = 0;
 		scrollbar->effect.is_running = FALSE;
 		scrollbar->old_pos = scrollbar->pos;
-		if (scrollbar->is_dragged) {
+		if (scrollbar->is_dragging) {
 			return;
 		}
 		scrollbar->mouse_x = point->x;
@@ -487,11 +499,11 @@ static void ScrollBox_OnTouch(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 	case LCUI_WEVENT_TOUCHUP:
 		Widget_ReleaseTouchCapture(box, -1);
 		time_delta = (uint_t)LCUI_GetTimeDelta(scrollbar->timestamp);
-		if (scrollbar->is_dragged && time_delta < 50) {
+		if (scrollbar->is_dragging && time_delta < 50) {
 			StartInertialScrolling(w);
 		}
 		scrollbar->touch_point_id = -1;
-		scrollbar->is_dragged = FALSE;
+		scrollbar->is_dragging = FALSE;
 		Widget_BlockEvent(box, FALSE);
 		break;
 	case LCUI_WEVENT_TOUCHMOVE:
@@ -500,7 +512,7 @@ static void ScrollBox_OnTouch(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 		}
 		e->cancel_bubble = TRUE;
 		pos = scrollbar->old_pos;
-		if (scrollbar->direction == SBD_HORIZONTAL) {
+		if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
 			pos -= point->x - scrollbar->mouse_x;
 		} else {
 			pos -= point->y - scrollbar->mouse_y;
@@ -517,20 +529,20 @@ static void ScrollBox_OnTouch(LCUI_Widget box, LCUI_WidgetEvent e, void *arg)
 		scrollbar->distance = distance;
 		scrollbar->timestamp = LCUI_GetTime();
 		ScrollBar_SetPosition(w, pos);
-		if (scrollbar->is_dragged) {
+		if (scrollbar->is_dragging) {
 			break;
 		}
 		/* If the position of the scroll bar is not changed, then
 		 * mark current drag action should be ignore */
 		if (scrollbar->is_draggable &&
 		    scrollbar->old_pos == scrollbar->pos) {
-			scrollbar->is_dragged = FALSE;
+			scrollbar->is_dragging = FALSE;
 			scrollbar->is_draggable = FALSE;
 			e->cancel_bubble = FALSE;
 			break;
 		}
 		/* start drag action and block all events of box */
-		scrollbar->is_dragged = TRUE;
+		scrollbar->is_dragging = TRUE;
 		LCUIWidget_ClearEventTarget(NULL);
 		Widget_BlockEvent(box, TRUE);
 		Widget_SetTouchCapture(box, point->id);
@@ -555,7 +567,7 @@ static void ScrollBar_OnSetPosition(LCUI_Widget box, LCUI_WidgetEvent e,
 
 void ScrollBar_BindBox(LCUI_Widget w, LCUI_Widget box)
 {
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
 	if (scrollbar->box) {
 		Widget_UnbindEvent(scrollbar->box, "resize",
@@ -584,7 +596,7 @@ void ScrollBar_BindBox(LCUI_Widget w, LCUI_Widget box)
 
 void ScrollBar_BindTarget(LCUI_Widget w, LCUI_Widget target)
 {
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
 	if (scrollbar->target) {
 		Widget_RemoveClass(scrollbar->target, "scrollbar-target");
@@ -599,15 +611,15 @@ void ScrollBar_BindTarget(LCUI_Widget w, LCUI_Widget target)
 
 int ScrollBar_GetPosition(LCUI_Widget w)
 {
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 	return scrollbar->pos;
 }
 
 int ScrollBar_SetPosition(LCUI_Widget w, int pos)
 {
-	float new_pos, box_size, size, slider_pos;
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
-	LCUI_Widget slider = scrollbar->slider;
+	float new_pos, box_size, size, thumb_pos;
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
+	LCUI_Widget thumb = scrollbar->thumb;
 	LCUI_Widget target = scrollbar->target;
 	LCUI_WidgetEvent e = { 0 };
 
@@ -616,7 +628,7 @@ int ScrollBar_SetPosition(LCUI_Widget w, int pos)
 	}
 	new_pos = 1.0f * pos;
 	memset(&e, 0, sizeof(e));
-	if (scrollbar->direction == SBD_HORIZONTAL) {
+	if (scrollbar->direction == LCUI_SCROLLBAR_HORIZONTAL) {
 		size = scrollbar->target->box.outer.width;
 		if (scrollbar->box) {
 			box_size = scrollbar->box->box.content.width;
@@ -629,9 +641,9 @@ int ScrollBar_SetPosition(LCUI_Widget w, int pos)
 		if (new_pos < 0.0f) {
 			new_pos = 0.0f;
 		}
-		slider_pos = w->box.content.width - slider->width;
-		slider_pos = slider_pos * new_pos / (size - box_size);
-		Widget_SetStyle(slider, key_left, slider_pos, px);
+		thumb_pos = w->box.content.width - thumb->width;
+		thumb_pos = thumb_pos * new_pos / (size - box_size);
+		Widget_SetStyle(thumb, key_left, thumb_pos, px);
 		Widget_SetStyle(target, key_left, -new_pos, px);
 	} else {
 		size = scrollbar->target->box.outer.height;
@@ -646,36 +658,38 @@ int ScrollBar_SetPosition(LCUI_Widget w, int pos)
 		if (new_pos < 0) {
 			new_pos = 0;
 		}
-		slider_pos = w->box.content.height - slider->height;
+		thumb_pos = w->box.content.height - thumb->height;
 		if (size == box_size) {
-			slider_pos = 0;
+			thumb_pos = 0;
 		} else {
-			slider_pos = slider_pos * new_pos / (size - box_size);
+			thumb_pos = thumb_pos * new_pos / (size - box_size);
 		}
-		Widget_SetStyle(slider, key_top, slider_pos, px);
+		Widget_SetStyle(thumb, key_top, thumb_pos, px);
 		Widget_SetStyle(target, key_top, -new_pos, px);
 	}
 	pos = iround(new_pos);
 	if (scrollbar->pos != pos) {
-		LCUI_WidgetEventRec e = { 0 };
-		e.type = self.event_id;
+		LCUI_WidgetEventRec e;
+		LCUI_InitWidgetEvent(&e, "scroll");
 		e.cancel_bubble = TRUE;
 		Widget_TriggerEvent(target, &e, &new_pos);
 	}
 	scrollbar->pos = pos;
-	Widget_UpdateStyle(slider, FALSE);
+	Widget_UpdateStyle(thumb, FALSE);
 	Widget_UpdateStyle(target, FALSE);
 	return pos;
 }
 
-void ScrollBar_SetDirection(LCUI_Widget w, int direction)
+void ScrollBar_SetDirection(LCUI_Widget w, LCUI_ScrollBarDirection direction)
 {
-	LCUI_ScrollBar scrollbar = Widget_GetData(w, self.prototype);
+	LCUI_ScrollBar scrollbar = Widget_GetData(w, scrollbar_prototype);
 
-	if (direction == SBD_HORIZONTAL) {
-		Widget_RemoveClass(w, "scrollbar-horizontal");
+	if (direction == LCUI_SCROLLBAR_HORIZONTAL) {
+		Widget_AddClass(w, "horizontal");
+		Widget_RemoveClass(w, "vertical");
 	} else {
-		Widget_AddClass(w, "scrollbar-horizontal");
+		Widget_AddClass(w, "vertical");
+		Widget_RemoveClass(w, "horizontal");
 	}
 	scrollbar->direction = direction;
 }
@@ -695,19 +709,19 @@ static void ScrollBar_OnSetAttr(LCUI_Widget w, const char *name,
 		if (target) {
 			ScrollBar_BindTarget(w, target);
 		}
+	} else if (strcmp(name, "direction") == 0) {
+		if (strcmp(value, "horizontal") == 0) {
+			ScrollBar_SetDirection(w, LCUI_SCROLLBAR_HORIZONTAL);
+		} else {
+			ScrollBar_SetDirection(w, LCUI_SCROLLBAR_VERTICAL);
+		}
 	}
 }
 
 void LCUIWidget_AddTScrollBar(void)
 {
-	int setscroll_event_id;
-
-	self.prototype = LCUIWidget_NewPrototype("scrollbar", NULL);
-	self.prototype->init = ScrollBar_OnInit;
-	self.prototype->setattr = ScrollBar_OnSetAttr;
-	self.event_id = LCUIWidget_AllocEventId();
-	setscroll_event_id = LCUIWidget_AllocEventId();
-	LCUIWidget_SetEventName(self.event_id, "scroll");
-	LCUIWidget_SetEventName(setscroll_event_id, "setscroll");
+	scrollbar_prototype = LCUIWidget_NewPrototype("scrollbar", NULL);
+	scrollbar_prototype->init = ScrollBar_OnInit;
+	scrollbar_prototype->setattr = ScrollBar_OnSetAttr;
 	LCUI_LoadCSSString(scrollbar_css, __FILE__);
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,7 +32,8 @@ test_widget_opacity.c \
 test_widget_event.c \
 test_textview_resize.c \
 test_textedit.c \
-test_settings.c
+test_settings.c \
+test_scrollbar.c
 
 test_LDADD = $(top_builddir)/src/libLCUI.la -lm $(CODE_COVERAGE_LIBS)
 
@@ -71,8 +72,9 @@ test_widget_opacity_CFLAGS = $(AM_CFLAGS) -D PREVIEW_MODE
 test_scaling_support_SOURCES = test_scaling_support.c
 test_scaling_support_LDADD = $(top_builddir)/src/libLCUI.la
 
-test_scrollbar_SOURCES = test_scrollbar.c
+test_scrollbar_SOURCES = test_scrollbar.c libtest.c
 test_scrollbar_LDADD = $(top_builddir)/src/libLCUI.la
+test_scrollbar_CFLAGS = $(AM_CFLAGS) -D PREVIEW_MODE
 
 test_widget_SOURCES = test_widget.c
 test_widget_LDADD = $(top_builddir)/src/libLCUI.la

--- a/test/test.c
+++ b/test/test.c
@@ -25,6 +25,7 @@ int main(void)
 	describe("test widget opacity", test_widget_opacity);
 	describe("test textview resize", test_textview_resize);
 	describe("test textedit", test_textedit);
+	describe("test scrollbar", test_scrollbar);
 	describe("test mainloop", test_mainloop);
 	describe("test css parser", test_css_parser);
 	describe("test block layout", test_block_layout);

--- a/test/test.h
+++ b/test/test.h
@@ -15,6 +15,7 @@ void test_widget_opacity(void);
 void test_widget_event(void);
 void test_textview_resize(void);
 void test_textedit(void);
+void test_scrollbar(void);
 void test_image_reader(void);
 
 void test_css_parser(void);

--- a/test/test_scrollbar.c
+++ b/test/test_scrollbar.c
@@ -1,29 +1,40 @@
-#include <LCUI_Build.h>
+#include "test.h"
+#include "libtest.h"
 #include <LCUI/LCUI.h>
 #include <LCUI/display.h>
+#include <LCUI/input.h>
 #include <LCUI/gui/widget.h>
 #include <LCUI/gui/widget/scrollbar.h>
 #include <LCUI/gui/builder.h>
 #include <LCUI/gui/css_parser.h>
 #include <LCUI/gui/widget/textview.h>
 
+/* clang-format off */
+
 const char *test_css = CodeToString(
 
 .container {
-	width: 640px;
+	width: 300px;
 	height: 240px;
 	padding: 10px;
 	margin: 20px auto 0 auto;
 	border: 1px solid #eee;
 }
 
+textview {
+	white-space: nowrap;
+	display: inline-block;
+}
+
 );
+
+/* clang-format on */
 
 const char *test_content = "\n\
 /* ***************************************************************************\n\
  * test_scrollbar.c -- test scrollbar\n\
  *\n\
- * Copyright (c) 2018, Liu chao <lc-soft@live.cn> All rights reserved.\n\
+ * Copyright (c) 2021, Liu chao <lc-soft@live.cn> All rights reserved.\n\
  *\n\
  * Redistribution and use in source and binary forms, with or without\n\
  * modification, are permitted provided that the following conditions are met:\n\
@@ -54,40 +65,169 @@ const char *test_content = "\n\
 /* Build content view with native C code */
 void BuildContentView(void)
 {
-        LCUI_Widget root = LCUIWidget_GetRoot();
+	LCUI_Widget root = LCUIWidget_GetRoot();
 	LCUI_Widget container = LCUIWidget_New(NULL);
 	LCUI_Widget content = LCUIWidget_New("textview");
-	LCUI_Widget scrollbar = LCUIWidget_New("scrollbar");
+	LCUI_Widget vscrollbar = LCUIWidget_New("scrollbar");
+	LCUI_Widget hscrollbar = LCUIWidget_New("scrollbar");
 
+	Widget_SetId(content, "license_content");
 	TextView_SetText(content, test_content);
-	ScrollBar_BindTarget(scrollbar, content);
+	ScrollBar_SetDirection(hscrollbar, LCUI_SCROLLBAR_HORIZONTAL);
+	ScrollBar_BindTarget(vscrollbar, content);
+	ScrollBar_BindTarget(hscrollbar, content);
 	Widget_AddClass(container, "container");
 	Widget_Append(container, content);
-	Widget_Append(container, scrollbar);
+	Widget_Append(container, vscrollbar);
+	Widget_Append(container, hscrollbar);
 	Widget_Append(root, container);
 }
 
 /* Build content view with the XML code in test_scrollbar.xml */
 int BuildContentViewFromXML(void)
 {
-        LCUI_Widget root = LCUIWidget_GetRoot();
-        LCUI_Widget pack = LCUIBuilder_LoadFile("test_scrollbar.xml");
+	LCUI_Widget root = LCUIWidget_GetRoot();
+	LCUI_Widget pack = LCUIBuilder_LoadFile("test_scrollbar.xml");
 
-        if (!pack) {
-                return -1;
-        }
-        Widget_Append(root, pack);
-        Widget_Unwrap(pack);
+	if (!pack) {
+		return -1;
+	}
+	Widget_Append(root, pack);
+	Widget_Unwrap(pack);
 	return 0;
 }
 
+void test_scrollbar(void)
+{
+	float left, top;
+	LCUI_SysEventRec e;
+	LCUI_Widget content;
+
+	LCUI_Init();
+	LCUIDisplay_SetSize(800, 640);
+	LCUI_LoadCSSString(test_css, __FILE__);
+	BuildContentView();
+	LCUI_RunFrame();
+
+	content = LCUIWidget_GetById("license_content");
+	left = content->computed_style.left;
+	top = content->computed_style.top;
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 300;
+	e.motion.y = 275;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	e.type = LCUI_MOUSEDOWN;
+	e.button.button = LCUI_KEY_LEFTBUTTON;
+	e.button.x = 300;
+	e.button.y = 275;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 600;
+	e.motion.y = 275;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	it_b("content should be moved to the left",
+	     content->computed_style.left < left &&
+		 top == content->computed_style.top,
+	     TRUE);
+
+	left = content->computed_style.left;
+	top = content->computed_style.top;
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 400;
+	e.motion.y = 275;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	e.type = LCUI_MOUSEUP;
+	e.button.button = LCUI_KEY_LEFTBUTTON;
+	e.button.x = 400;
+	e.button.y = 275;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	it_b("content should be moved to the right",
+	     content->computed_style.left > left &&
+		 top == content->computed_style.top,
+	     TRUE);
+
+	left = content->computed_style.left;
+	top = content->computed_style.top;
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 555;
+	e.motion.y = 45;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	e.type = LCUI_MOUSEDOWN;
+	e.button.button = LCUI_KEY_LEFTBUTTON;
+	e.button.x = 555;
+	e.button.y = 45;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 555;
+	e.motion.y = 200;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	it_b("content should be moved to the top",
+	     content->computed_style.left == left &&
+		 top > content->computed_style.top,
+	     TRUE);
+
+	left = content->computed_style.left;
+	top = content->computed_style.top;
+
+	e.type = LCUI_MOUSEMOVE;
+	e.motion.x = 555;
+	e.motion.y = 100;
+	e.motion.xrel = 0;
+	e.motion.yrel = 0;
+	LCUI_TriggerEvent(&e, NULL);
+	e.type = LCUI_MOUSEUP;
+	e.button.button = LCUI_KEY_LEFTBUTTON;
+	e.button.x = 555;
+	e.button.y = 100;
+	LCUI_TriggerEvent(&e, NULL);
+	LCUI_RunFrame();
+
+	it_b("the content should have scrolled to the bottom",
+	     content->computed_style.left == left &&
+		 top < content->computed_style.top,
+	     TRUE);
+
+	LCUI_Destroy();
+}
+
+#ifdef PREVIEW_MODE
+
 int main(int argc, char **argv)
 {
-        LCUI_Init();
+	LCUI_Init();
 	LCUIDisplay_SetSize(800, 640);
 	LCUI_LoadCSSString(test_css, __FILE__);
 	/* We have two ways to build content view */
 	BuildContentViewFromXML();
 	BuildContentView();
-        return LCUI_Main();
+	return LCUI_Main();
 }
+
+#endif

--- a/test/test_scrollbar.xml
+++ b/test/test_scrollbar.xml
@@ -2,11 +2,11 @@
 <lcui-app>
   <ui>
     <w class="container">
-      <w id="content" type="textview">
+      <textview id="content">
 /* ***************************************************************************
  * test_scrollbar.c -- test scrollbar
  *
- * Copyright (c) 2018, Liu chao &lt;lc-soft@live.cn&gt; All rights reserved.
+ * Copyright (c) 2021, Liu chao &lt;lc-soft@live.cn&gt; All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,8 +32,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-      </w>
-      <w type="scrollbar" target="content" />
+      </textview>
+      <scrollbar target="content" />
+      <scrollbar target="content" direction="horizontal" />
     </w>
   </ui>
 </lcui-app>


### PR DESCRIPTION
Fixes  #219

Changes proposed in this pull request:

- [x] Rename css class name.
- [x] Use the `LCUI_ScrollBar` prefix instead of the `SBD_` prefix to make the enumeration easier to understand.
- [x] Add test.
