### PR TITLE
fix(gui): the size of the absolutely positioned widget is incorrect

### DIFF
--- a/include/LCUI/gui/widget_layout.h
+++ b/include/LCUI/gui/widget_layout.h
@@ -33,4 +33,6 @@
 
 LCUI_API void Widget_Reflow(LCUI_Widget w, LCUI_LayoutRule rule);
 
+LCUI_API LCUI_BOOL Widget_AutoReflow(LCUI_Widget w, LCUI_LayoutRule rule);
+
 #endif

--- a/src/gui/layout/block.c
+++ b/src/gui/layout/block.c
@@ -235,6 +235,12 @@ static void BlockLayout_Load(LCUI_BlockLayoutContext ctx)
 			LinkedList_Append(&ctx->free_elements, child);
 			continue;
 		}
+		/*
+		 * If the width of the child widget depends on the width of
+		 * the parent widget, we need to calculate the intrinsic
+		 * maximum width of its content to calculate the appropriate
+		 * size of the widget's content area.
+		 */
 		if (child->computed_style.width_sizing !=
 			LCUI_SIZING_RULE_FIXED &&
 		    child->computed_style.width_sizing !=
@@ -324,17 +330,9 @@ static void BlockLayout_ReflowRow(LCUI_BlockLayoutContext ctx, float row_y)
 
 static void BlockLayout_ReflowFreeElements(LCUI_BlockLayoutContext ctx)
 {
-	LCUI_Widget w;
 	LinkedListNode *node;
-
 	for (LinkedList_Each(node, &ctx->free_elements)) {
-		w = node->data;
-		Widget_ComputeSizeStyle(w);
-		Widget_UpdateBoxSize(w);
-		Widget_UpdateBoxPosition(w);
-		Widget_AddState(w, LCUI_WSTATE_LAYOUTED);
-		w->proto->resize(w, w->box.content.width,
-				 w->box.content.height);
+		Widget_AutoReflow(node->data, LCUI_LAYOUT_RULE_FIXED);
 	}
 }
 

--- a/src/gui/widget_base.c
+++ b/src/gui/widget_base.c
@@ -433,23 +433,6 @@ LCUI_BOOL Widget_HasAutoStyle(LCUI_Widget w, int key)
 	       Widget_CheckStyleType(w, key, AUTO);
 }
 
-LCUI_SizingRule Widget_GetHeightSizingRule(LCUI_Widget w)
-{
-	if (!Widget_HasAutoStyle(w, key_height)) {
-		return LCUI_SIZING_RULE_FIXED;
-	}
-	if (!w->parent || Widget_HasAbsolutePosition(w)) {
-		return LCUI_SIZING_RULE_FIT_CONTENT;
-	}
-	if (w->parent->computed_style.display == SV_FLEX) {
-		if (w->parent->computed_style.flex.direction == SV_COLUMN) {
-			return LCUI_SIZING_RULE_NONE;
-		}
-		return LCUI_SIZING_RULE_FILL;
-	}
-	return LCUI_SIZING_RULE_FIT_CONTENT;
-}
-
 void Widget_SetText(LCUI_Widget w, const char *text)
 {
 	if (w->proto && w->proto->settext) {

--- a/src/gui/widget_layout.c
+++ b/src/gui/widget_layout.c
@@ -36,6 +36,7 @@
 #include <LCUI/gui/metrics.h>
 #include "layout/block.h"
 #include "layout/flexbox.h"
+#include "widget_diff.h"
 
 void Widget_Reflow(LCUI_Widget w, LCUI_LayoutRule rule)
 {
@@ -58,4 +59,25 @@ void Widget_Reflow(LCUI_Widget w, LCUI_LayoutRule rule)
 	Widget_TriggerEvent(w, &ev, NULL);
 	DEBUG_MSG("id: %s, type: %s, size: (%g, %g)\n", w->id, w->type,
 		  w->width, w->height);
+}
+
+LCUI_BOOL Widget_AutoReflow(LCUI_Widget w, LCUI_LayoutRule rule)
+{
+	float content_width = w->box.padding.width;
+	float content_height = w->box.padding.height;
+	LCUI_WidgetLayoutDiffRec diff;
+
+	Widget_BeginLayoutDiff(w, &diff);
+	Widget_ComputeSizeStyle(w);
+	Widget_UpdateBoxSize(w);
+	Widget_UpdateBoxPosition(w);
+	Widget_AddState(w, LCUI_WSTATE_LAYOUTED);
+	if (content_width == w->box.padding.width &&
+	    content_height == w->box.padding.height) {
+		return FALSE;
+	}
+	Widget_Reflow(w, rule);
+	Widget_EndLayoutDiff(w, &diff);
+	w->task.states[LCUI_WTASK_REFLOW] = FALSE;
+	return TRUE;
 }

--- a/src/gui/widget_style.c
+++ b/src/gui/widget_style.c
@@ -218,6 +218,9 @@ void Widget_ComputeWidthStyle(LCUI_Widget w)
 				    LCUI_SIZING_RULE_FIT_CONTENT;
 				break;
 			}
+			// TODO: Improved sizing rule calculation
+			// We should consider whether to use other rules when
+			// the display value is inline-block, inline-flex or flex.
 			style->width_sizing = LCUI_SIZING_RULE_FILL;
 			if (w->parent->computed_style.width_sizing ==
 			    LCUI_SIZING_RULE_FIXED) {


### PR DESCRIPTION
Before:

![before7](https://user-images.githubusercontent.com/1730073/119265062-f07e2280-bc17-11eb-89a1-dbdf8dc8dcbb.png)


After:

![after](https://user-images.githubusercontent.com/1730073/119264959-a39a4c00-bc17-11eb-9584-c0e0d525fa9d.png)
