### PR TITLE
fix: format-overflow error in gcc 14

### DIFF
--- a/lib/css/src/library.c
+++ b/lib/css/src/library.c
@@ -445,7 +445,7 @@ static void css_each_style_link(css_style_link_t *link, const char *selector,
         char fullname[CSS_SELECTOR_MAX_LEN];
 
         if (selector) {
-                sprintf(fullname, "%s %s", link->group->name, selector);
+                snprintf(fullname, sizeof(fullname), "%s %s", link->group->name, selector);
         } else {
                 strcpy(fullname, link->group->name);
         }


### PR DESCRIPTION
log:
format-overflow 从 gcc 14 开始被视为`错误`而非`警告`
> error: lib/css/src/library.c:448:41: 错误：‘sprintf’ may write a terminating nul past the end of the destination [-Werror=format-overflow=]
>  448 |                 sprintf(fullname, "%s %s", link->group->name, selector);
>      |

参考：
https://stackoverflow.com/questions/73769693/how-to-fix-warning-sprintf-swriting-a-termination-nul-past-the-end-ot-the-dest

Fixes #???.

Changes proposed in this pull request:
- 
-
-

@lc-soft
